### PR TITLE
async-embedded: Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ version = "0.0.0-alpha.0"
 dependencies = [
  "cortex-m",
  "cortex-m-udf",
- "generic-array 0.13.2",
+ "generic-array 0.14.2",
  "heapless 0.5.3 (git+https://github.com/japaric/heapless?branch=slab)",
  "pin-utils",
  "riscv",
@@ -134,6 +134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac746a5f3bbfdadd6106868134545e684693d54d9d44f6e9588a7d54af0bf980"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hash32"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "pin-utils"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -310,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.11.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-xid"
@@ -325,6 +335,12 @@ name = "vcell"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876e32dcadfe563a4289e994f7cb391197f362b6315dc45e8ba4aa6f564a4b3c"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "volatile-register"

--- a/async-embedded/Cargo.toml
+++ b/async-embedded/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 version = "0.0.0-alpha.0"
 
 [dependencies]
-generic-array = "0.13.2"
+generic-array = "0.14.2"
 heapless = { git = "https://github.com/japaric/heapless", branch = "slab" }
-pin-utils = "0.1.0-alpha.4"
-typenum = "1.11.2"
+pin-utils = "0.1.0"
+typenum = "1.12.0"
 
 [target.'cfg(target_arch = "arm")'.dependencies]
 cortex-m = "0.6.2"


### PR DESCRIPTION
This upgrades the dependencies of `async-embedded`.
Most importantly this upgrades `pin-utils` to its first non-alpha release.

What do you think?